### PR TITLE
修复叠加层大小不随页面变化而变化的问题

### DIFF
--- a/bilibili_blocked_videos_by_tags.user.js
+++ b/bilibili_blocked_videos_by_tags.user.js
@@ -1749,6 +1749,24 @@ function hideNonVideoElements() {
     });
 }
 
+// 叠加层参数(背景)
+GM_addStyle(`
+.blockedOverlay {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-color: rgba(60, 60, 60, 0.85);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    z-index: 10;
+    backdrop-filter: blur(6px);
+    border-radius: 6px;
+}
+`);
+
 // 屏蔽或者取消屏蔽
 function blockedOrUnblocked(videoElement, videoBv, setTimeoutStatu = false) {
     // 是白名单目标，是屏蔽目标，没有隐藏、没有叠加层：跳过
@@ -1840,22 +1858,8 @@ function blockedOrUnblocked(videoElement, videoBv, setTimeoutStatu = false) {
                 return;
             }
 
-            // 获取 videoElement 的尺寸
-            const elementRect = videoElement.getBoundingClientRect();
-
-            // 叠加层参数(背景)
             let overlay = document.createElement("div");
             overlay.className = "blockedOverlay";
-            overlay.style.position = "absolute";
-            overlay.style.width = elementRect.width + "px"; // 使用 videoElement 的宽度
-            overlay.style.height = elementRect.height + "px"; // 使用 videoElement 的高度
-            overlay.style.backgroundColor = "rgba(60, 60, 60, 0.85)";
-            overlay.style.display = "flex";
-            overlay.style.justifyContent = "center";
-            overlay.style.alignItems = "center";
-            overlay.style.zIndex = "10";
-            overlay.style.backdropFilter = "blur(6px)";
-            overlay.style.borderRadius = "6px";
 
             // 叠加层文本参数(背景)
             let overlayText = document.createElement("div");


### PR DESCRIPTION
before:

![screenshot](https://github.com/tjxwork/bilibili_blocked_videos_by_tags/assets/51886614/89066a8e-82f7-4554-b2f3-ca0cfe08d532)

复现：开着devtools刷新页面，等叠加层出现后关掉devtools（或者其他任何能引起元素的大小变化的操作？）

---

`width: 100%; height: 100%;`好像效果差不多，但看到<https://stackoverflow.com/questions/12126349/css-height100-vs-bottom0>好像不太一样，我不太懂所以用了应该更保险的`left,right,top,bottom`