### PR TITLE
新增标题关键词白名单和标签白名单功能

### DIFF
--- a/bilibili_blocked_videos_by_tags.user.js
+++ b/bilibili_blocked_videos_by_tags.user.js
@@ -2499,8 +2499,8 @@ function handleWhitelistNameOrUid(videoBv) {
 }
 
 function handleWhitelistTag(videoBv) {
-    // 判断是否拿到视频标签，以及开关是否开启
-    if (!videoInfoDict[videoBv].videoTags || !blockedParameter.whitelistTag_Switch) {
+    // 判断是否拿到视频标签
+    if (!videoInfoDict[videoBv].videoTags) {
         return;
     }
 

--- a/bilibili_blocked_videos_by_tags.user.js
+++ b/bilibili_blocked_videos_by_tags.user.js
@@ -3108,7 +3108,8 @@ function FuckYouBilibiliRecommendationSystem() {
             handleWhitelistTag(videoBv);
         }
 
-        if (blockedParameter.whitelistTitle_Switch && blockedParameter.whitelistTag_Array.length > 0){
+        // 是否启用 白名单标题
+        if (blockedParameter.whitelistTitle_Switch && blockedParameter.whitelistTitle_Array.length > 0){
             // 判断处理 白名单标题
             handleWhitelistTitle(videoBv);
         }

--- a/bilibili_blocked_videos_by_tags.user.js
+++ b/bilibili_blocked_videos_by_tags.user.js
@@ -111,7 +111,10 @@ let blockedParameter = GM_getValue("GM_blockedParameter", {
     blockedTag_Switch: true,
     blockedTag_UseRegular: true,
     blockedTag_Array: [],
-
+    // 白名单标签
+    whitelistTag_Switch: true,
+    whitelistTag_UseRegular: true,
+    whitelistTag_Array: [],
     // 屏蔽双重屏蔽标签
     doubleBlockedTag_Switch: true,
     doubleBlockedTag_UseRegular: true,
@@ -672,6 +675,26 @@ let menuUiHTML = `
             </ul>
         </div>
 
+        <div class="menuOptions">
+            <div class="titleLabelLeft">
+                <label title="白名单，标签匹配成功后将不会被屏蔽，优先级最高"><input type="checkbox"
+                        v-model="menuUiSettings.whitelistTag_Switch" />按标签避免屏蔽视频(?)</label>
+            </div>
+
+            <div class="titleLabelRight">
+                <label title="正则是什么可以问AI，你也可以理解成模糊匹配"><input type="checkbox" v-model="menuUiSettings.whitelistTag_UseRegular" />启用正则(?)</label>
+            </div>
+
+            <input type="text" placeholder='多项输入请用英文逗号间隔' spellcheck="false"
+                v-model="tempInputValue.whitelistTag_Array" /><button
+                @click="addArrayButton(tempInputValue, menuUiSettings, 'whitelistTag_Array' )">添加</button>
+
+            <ul>
+                <li v-for="(value, index) in menuUiSettings.whitelistTag_Array">
+                    {{getDisplayText(value, index)}}<button @click="delArrayButton(index, menuUiSettings.whitelistTag_Array)">×</button>
+                </li>
+            </ul>
+        </div>
 
         <div class="menuOptions">
             <label title="视频API，是拿到视频的充电视频标记后判断的"><input type="checkbox" v-model="menuUiSettings.blockedChargingExclusive_Switch" />屏蔽充电专属的视频(?)</label>
@@ -951,6 +974,7 @@ function blockedMenuUi() {
                 blockedNameOrUid_Array: "",
                 blockedVideoPartitions_Array: "",
                 blockedTag_Array: "",
+                whitelistTag_Array:"",
                 doubleBlockedTag_Array: "",
                 blockedTopComment_Array: "",
                 blockedUpSigns_Array: "",
@@ -2449,6 +2473,31 @@ function handleWhitelistNameOrUid(videoBv) {
     }
 }
 
+function handleWhitelistTag(videoBv) {
+    // 判断是否拿到视频标签，以及开关是否开启
+    if (!videoInfoDict[videoBv].videoTags || !blockedParameter.whitelistTag_Switch) {
+        return;
+    }
+
+    let isMatch = false;
+
+    // 是否启用正则匹配
+    if (blockedParameter.whitelistTag_UseRegular) {
+        isMatch = blockedParameter.whitelistTag_Array.some((whitelistTagItem) => {
+            const regEx = new RegExp(whitelistTagItem);
+            return videoInfoDict[videoBv].videoTags.some((videoTagItem) => regEx.test(videoTagItem));
+        });
+    } else {
+        isMatch = blockedParameter.whitelistTag_Array.some((whitelistTagItem) =>
+            videoInfoDict[videoBv].videoTags.includes(whitelistTagItem)
+        );
+    }
+
+    if (isMatch) {
+        videoInfoDict[videoBv].whiteListTargets = true;
+    }
+}
+
 // 判断当前网址是否符合
 function determineURL(urlRules, currentUrl) {
     // 检查是否匹配任意规则
@@ -3003,7 +3052,11 @@ function FuckYouBilibiliRecommendationSystem() {
             // 判断处理 白名单Up主和Uid
             handleWhitelistNameOrUid(videoBv);
         }
-
+        // 是否启用 白名单Tag
+        if (blockedParameter.whitelistTag_Switch && blockedParameter.whitelistTag_Array.length > 0){
+            // 判断处理 白名单Tag
+            handleWhitelistTag(videoBv);
+        }
         // 屏蔽或者取消屏蔽
         blockedOrUnblocked(videoElement, videoBv);
 

--- a/bilibili_blocked_videos_by_tags.user.js
+++ b/bilibili_blocked_videos_by_tags.user.js
@@ -96,7 +96,10 @@ let blockedParameter = GM_getValue("GM_blockedParameter", {
     blockedTitle_Switch: true,
     blockedTitle_UseRegular: true,
     blockedTitle_Array: [],
-
+    // 标题关键字白名单
+    whitelistTitle_Switch: true,
+    whitelistTitle_UseRegular:true,
+    whitelistTitle_Array: [],
     // 屏蔽Up主和Uid
     blockedNameOrUid_Switch: true,
     blockedNameOrUid_UseRegular: false,
@@ -611,6 +614,27 @@ let menuUiHTML = `
 
         <div class="menuOptions">
             <div class="titleLabelLeft">
+                <label title="标题白名单，命中关键字的视频将不会被屏蔽，优先级最高"><input type="checkbox"
+                        v-model="menuUiSettings.whitelistTitle_Switch" />按标题避免屏蔽视频(?)</label>
+            </div>
+
+            <div class="titleLabelRight">
+                <label title="正则是什么可以问AI，你也可以理解成模糊匹配"><input type="checkbox" v-model="menuUiSettings.whitelistTitle_UseRegular" />启用正则(?)</label>
+            </div>
+
+            <input type="text" placeholder='多项输入请用英文逗号间隔' spellcheck="false"
+                v-model="tempInputValue.whitelistTitle_Array" /><button
+                @click="addArrayButton(tempInputValue, menuUiSettings, 'whitelistTitle_Array' )">添加</button>
+
+            <ul>
+                <li v-for="(value, index) in menuUiSettings.whitelistTitle_Array">
+                    {{getDisplayText(value, index)}}<button @click="delArrayButton(index, menuUiSettings.whitelistTitle_Array)">×</button>
+                </li>
+            </ul>
+        </div>
+        
+        <div class="menuOptions">
+            <div class="titleLabelLeft">
                 <label title="大部分情况也是可以在网页上直接拿到"><input type="checkbox" v-model="menuUiSettings.blockedNameOrUid_Switch" />按UP名称或Uid屏蔽视频(?)</label>
             </div>
 
@@ -971,6 +995,7 @@ function blockedMenuUi() {
             // 临时存储的各数组对应的输入值
             const tempInputValue = reactive({
                 blockedTitle_Array: "",
+                whitelistTitle_Array: "",
                 blockedNameOrUid_Array: "",
                 blockedVideoPartitions_Array: "",
                 blockedTag_Array: "",
@@ -2498,6 +2523,31 @@ function handleWhitelistTag(videoBv) {
     }
 }
 
+function handleWhitelistTitle(videoBv) {
+    // 判断是否拿到视频标题，以及白名单开关是否开启
+    if (!videoInfoDict[videoBv].videoTitle) {
+        return;
+    }
+
+    let isMatch = false;
+
+    // 是否启用正则匹配
+    if (blockedParameter.whitelistTitle_UseRegular) {
+        isMatch = blockedParameter.whitelistTitle_Array.some((whitelistTitleItem) => {
+            const regEx = new RegExp(whitelistTitleItem);
+            return regEx.test(videoInfoDict[videoBv].videoTitle);
+        });
+    } else {
+        isMatch = blockedParameter.whitelistTitle_Array.some((whitelistTitleItem) => {
+            return whitelistTitleItem === videoInfoDict[videoBv].videoTitle;
+        });
+    }
+
+    if (isMatch) {
+        videoInfoDict[videoBv].whiteListTargets = true;
+    }
+}
+
 // 判断当前网址是否符合
 function determineURL(urlRules, currentUrl) {
     // 检查是否匹配任意规则
@@ -3057,6 +3107,12 @@ function FuckYouBilibiliRecommendationSystem() {
             // 判断处理 白名单Tag
             handleWhitelistTag(videoBv);
         }
+
+        if (blockedParameter.whitelistTitle_Switch && blockedParameter.whitelistTag_Array.length > 0){
+            // 判断处理 白名单标题
+            handleWhitelistTitle(videoBv);
+        }
+
         // 屏蔽或者取消屏蔽
         blockedOrUnblocked(videoElement, videoBv);
 


### PR DESCRIPTION
**新增功能**
- 标签白名单
- 标题白名单

**用途**
一些优质视频可能会使用热门标签进行引流，在开启大批量关键词/标签屏蔽时容易误伤
添加白名单来解决误伤问题，尽管问题解决程度取决于用户

**使用例**
用户在屏蔽列表加入了原神，但用户想看带飞八分钱关键字的鬼畜，将飞八分钱添加到标题/标签白名单后，带飞八分钱和原神的视频不会被误伤